### PR TITLE
Fixes incorrect statement about root nodes in the Merkle tree theory

### DIFF
--- a/src/ch01-02-merkle-tree.md
+++ b/src/ch01-02-merkle-tree.md
@@ -218,7 +218,7 @@ __signatures__
 TODO
 
 ## Root Nodes
-If the number of leaf nodes is a multiple of 2 the flat tree will only have a
+If the number of leaf nodes is a power of 2 the flat tree will only have a
 single root. Otherwise it'll have more than one.
 
 ## Storage Format


### PR DESCRIPTION
<!--
Thanks for creating a Pull Request 😄 ! Before you submit, please read the following:
- Read our CONTRIBUTING.md file before submitting a patch.
- By making a contribution, you agree to our Developer Certificate of Origin.
-->

**🐛 bug fix

The statement:

> If the number of leaf nodes is a multiple of 2 the flat tree will only have a single root.

is incorrect and should rather state:

> If the number of leaf nodes is a power of 2 the flat tree will only have a single root.


## Checklist
- [x] documentation is changed or added

## Context
No

## Semver Changes
N/A
